### PR TITLE
Add parse utility for pkg-config.

### DIFF
--- a/pkgconfig/pkgconfig.py
+++ b/pkgconfig/pkgconfig.py
@@ -24,6 +24,7 @@ tool."""
 
 import subprocess
 import re
+import collections
 
 
 def _compare_versions(v1, v2):
@@ -134,3 +135,46 @@ def installed(package, version):
 
     if comparator == '<=':
         return result <= 0
+
+
+_PARSE_MAP = {
+    '-D': 'define_macros',
+    '-I': 'include_dirs',
+    '-L': 'library_dirs',
+    '-l': 'libraries'
+}
+
+
+def parse(package):
+    """
+    Parse the output from pkg-config about the passed package.
+
+    Builds a dictionary containing the 'libraries', the 'library_dirs',
+    the 'include_dirs', and the 'define_macros' that are presented by
+    pkg-config.
+    """
+    result = collections.defaultdict(set)
+
+    # Execute the query to pkg-config and clean the result.
+    out = _query(package, '--cflags --libs')
+    out = out.replace('\\"', '')
+
+    # Iterate through each token in the output.
+    for token in out.split():
+        key = _PARSE_MAP.get(token[:2])
+        if key:
+            result[key].add(token[2:].strip())
+
+    # Iterate and clean define macros.
+    macros = set()
+    for declaration in result['define_macros']:
+        macro = tuple(declaration.split('='))
+        if len(macro) == 1:
+            macro += '',
+
+        macros.add(macro)
+
+    result['define_macros'] = macros
+
+    # Return parsed configuration.
+    return result

--- a/test.py
+++ b/test.py
@@ -37,3 +37,12 @@ def test_libs():
 
     for flag in flags.split(' '):
         nt.assert_true(flag in ('-L/usr/lib64', '-lgtk-3'))
+
+
+def test_parse():
+    config = pkgconfig.parse(PACKAGE_NAME)
+
+    nt.assert_true(('GSEAL_ENABLE', '') in config['define_macros'])
+    nt.assert_true('/usr/include/gtk-3.0' in config['include_dirs'])
+    nt.assert_true('/usr/lib64' in config['library_dirs'])
+    nt.assert_true('gtk-3' in config['libraries'])


### PR DESCRIPTION
A utility to parse out information from pkg-config into a dictionary consumable by python.

``` python
config = pkgconfig.parse('gtk+-3.0')

assert ('GSEAL_ENABLE', '') in config['define_macros']
assert '/usr/include/gtk-3.0' in config['include_dirs']
assert '/usr/lib64' in config['library_dirs']
assert 'gtk-3' in config['libraries']
```
