### PR TITLE
No need to loop over packages. pkg-config can take several packages a…

### DIFF
--- a/pkgconfig/pkgconfig.py
+++ b/pkgconfig/pkgconfig.py
@@ -201,15 +201,10 @@ def parse(packages):
         # Return parsed configuration.
         return result
 
-    # Go through all package names and update the result dict accordingly.
-    result = collections.defaultdict(list)
+    # Return the result of parse_package directly.
+    # We don't need to loop over the packages
 
-    for package in packages.split():
-        for k, v in parse_package(package).items():
-            # Appending would create a list of lists
-            result[k] = result[k] + v
-
-    return result
+    return parse_package(packages)
 
 
 def list_all():


### PR DESCRIPTION
…t once.

This particular issue was not visible while using set for the output of `pkgconfig.parse`. Once I moved from set to list it became apparent that the output `pkgconfig.libs` and `pkgconfig.parse(..)['libraries']` can become inconsistent when called with more than package. `pkg-config` will operate some reductions on its output when called with multiple packages. The current direct call to `pkgconfig.libs` and other will restitute faithfully the output of `pkg-config` but `pkgconfig.parse` does not. This PR makes the output  of `pkg-config.parse` faithful to the expected output of `pkg-config`.