### PR TITLE
add function that returns all variables defined in a .pc file

### DIFF
--- a/pkgconfig/pkgconfig.py
+++ b/pkgconfig/pkgconfig.py
@@ -23,7 +23,8 @@
 tool."""
 
 import os
-import subprocess
+from subprocess import call, PIPE, Popen
+import shlex
 import re
 import collections
 from functools import wraps
@@ -66,9 +67,8 @@ def _convert_error(func):
 @_convert_error
 def _query(package, option):
     pkg_config_exe = os.environ.get('PKG_CONFIG', None) or 'pkg-config'
-    cmd = '{0} {1} {2}'.format(pkg_config_exe, option, package).split()
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+    cmd = '{0} {1} {2}'.format(pkg_config_exe, option, package)
+    proc = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
     out, err = proc.communicate()
 
     return out.rstrip().decode('utf-8')
@@ -83,7 +83,7 @@ def exists(package):
     """
     pkg_config_exe = os.environ.get('PKG_CONFIG', None) or 'pkg-config'
     cmd = '{0} --exists {1}'.format(pkg_config_exe, package).split()
-    return subprocess.call(cmd) == 0
+    return call(cmd) == 0
 
 
 @_convert_error
@@ -108,6 +108,38 @@ def cflags(package):
 def libs(package):
     """Return the LDFLAGS string returned by pkg-config."""
     return _query(package, '--libs')
+
+
+def variables(package):
+    """Return a dictionary of all the variables defined in the .pc pkg-config
+     file of 'packae'"""
+
+    if exists(package):
+
+        pkg_config_exe = os.environ.get('PKG_CONFIG', None) or 'pkg-config'
+
+        # get the list of all the variables defined in the .pc file
+        cmd = '{0} {1} {2}'.format(
+            pkg_config_exe, '--print-variables', package)
+
+        proc = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
+        out, _ = proc.communicate()
+        _variables = filter(lambda x: x != '', out.decode('utf-8').split('\n'))
+
+        # get the variable values
+        retval = dict()
+        for variable in _variables:
+            cmd = '{0} --variable={1} {2}'.format(
+                pkg_config_exe, variable, package)
+            proc = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
+            out, _ = proc.communicate()
+            retval[variable] = out.decode('utf-8').strip()
+
+        return retval
+    else:
+        msg = ('package "{}" does not exist in PKG_CONFIG_PATH or\n'
+               'or something else went wrong').format(package)
+        raise ValueError(msg)
 
 
 def installed(package, version):

--- a/pkgconfig/pkgconfig.py
+++ b/pkgconfig/pkgconfig.py
@@ -23,11 +23,11 @@
 tool."""
 
 import os
-from subprocess import call, PIPE, Popen
 import shlex
 import re
 import collections
 from functools import wraps
+from subprocess import call, PIPE, Popen
 
 
 def _compare_versions(v1, v2):
@@ -113,33 +113,31 @@ def libs(package):
 def variables(package):
     """Return a dictionary of all the variables defined in the .pc pkg-config
      file of 'packae'"""
-
-    if exists(package):
-
-        pkg_config_exe = os.environ.get('PKG_CONFIG', None) or 'pkg-config'
-
-        # get the list of all the variables defined in the .pc file
-        cmd = '{0} {1} {2}'.format(
-            pkg_config_exe, '--print-variables', package)
-
-        proc = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
-        out, _ = proc.communicate()
-        _variables = filter(lambda x: x != '', out.decode('utf-8').split('\n'))
-
-        # get the variable values
-        retval = dict()
-        for variable in _variables:
-            cmd = '{0} --variable={1} {2}'.format(
-                pkg_config_exe, variable, package)
-            proc = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
-            out, _ = proc.communicate()
-            retval[variable] = out.decode('utf-8').strip()
-
-        return retval
-    else:
+    if not exists(package):
         msg = ('package "{}" does not exist in PKG_CONFIG_PATH or\n'
                'or something else went wrong').format(package)
         raise ValueError(msg)
+
+    pkg_config_exe = os.environ.get('PKG_CONFIG', None) or 'pkg-config'
+
+    # get the list of all the variables defined in the .pc file
+    cmd = '{0} {1} {2}'.format(
+        pkg_config_exe, '--print-variables', package)
+
+    proc = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
+    out, _ = proc.communicate()
+    _variables = filter(lambda x: x != '', out.decode('utf-8').split('\n'))
+
+    # get the variable values
+    retval = dict()
+    for variable in _variables:
+        cmd = '{0} --variable={1} {2}'.format(
+            pkg_config_exe, variable, package)
+        proc = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
+        out, _ = proc.communicate()
+        retval[variable] = out.decode('utf-8').strip()
+
+    return retval
 
 
 def installed(package, version):

--- a/test.py
+++ b/test.py
@@ -55,3 +55,17 @@ def test_listall():
     packages = pkgconfig.list_all()
     nt.assert_true('fake-gtk+-3.0' in packages)
     nt.assert_true('fake-python' in packages)
+
+
+def test_variables():
+    variables = pkgconfig.variables('fake-python')
+
+    nt.assert_true('prefix' in variables)
+    nt.assert_true('exec_prefix' in variables)
+    nt.assert_true('libdir' in variables)
+    nt.assert_true('includedir' in variables)
+
+    nt.assert_true(variables['prefix'] == '/usr')
+    nt.assert_true(variables['exec_prefix'] == '/usr')
+    nt.assert_true(variables['libdir'] == '/usr/lib_python_foo')
+    nt.assert_true(variables['includedir'] == '/usr/include')


### PR DESCRIPTION
The pkgconfig.parse() function returns a subset of the variables defined in the .pc file
of a package. 

I implemented another function ````pkgconfig.variables()```` that returns a dictionary
whose keys are the output of ````~> pkg-config --print-variables```` and the values are
their corresponding values defined in the .pc file. 

Also implemented the unit test.