### PR TITLE
Add python_requires and update python versions tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6"
 
 install:
     - pip install nose

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,6 @@ setup(
     description="Interface Python with pkg-config",
     long_description=open('README.rst').read(),
     setup_requires=['nose>=1.0'],
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
     test_suite='test',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34
+envlist = py26, py27, py33, py34, py35, py36
 
 [testenv]
 deps = nose


### PR DESCRIPTION
There a new(ish) setup keyword supported by setuptools and pip which allows for defining which versions of python a particular release supports, called `python_requires`. There's more info at
https://packaging.python.org/tutorials/distributing-packages/#python-requires, but this is useful when the latest release of a package does not support older python versions.

I've also updated the tox and travis file to include newer python versions.