### PR TITLE
Ensure defined macro without a value is None 

### DIFF
--- a/pkgconfig/pkgconfig.py
+++ b/pkgconfig/pkgconfig.py
@@ -222,7 +222,7 @@ def parse(packages):
         for declaration in result['define_macros']:
             macro = tuple(declaration.split('='))
             if len(macro) == 1:
-                macro += '',
+                macro += None,
 
             macros.append(macro)
 

--- a/test.py
+++ b/test.py
@@ -42,7 +42,7 @@ def test_libs():
 def test_parse():
     config = pkgconfig.parse("fake-gtk+-3.0 fake-python")
 
-    nt.assert_true(('GSEAL_ENABLE', '') in config['define_macros'])
+    nt.assert_true(('GSEAL_ENABLE', None) in config['define_macros'])
     nt.assert_true('/usr/include/gtk-3.0' in config['include_dirs'])
     nt.assert_true('/usr/lib_gtk_foo' in config['library_dirs'])
     nt.assert_true('/usr/lib_python_foo' in config['library_dirs'])


### PR DESCRIPTION
Change the behavior of `pkgconfig.parse('...')['define_macros']` to
produce `('MACRO_NAME', None)`, instead of `('MACRO_NAME', '')` when the
macro is defined without a value.  This allows for better integration
for expanding `**pkgconfig.parse()` as `kwargs` to distutils/setuptools
`setup()`. i.e.,:

    setuptools.Extension(
        # ...
        **pkgconfig.parse('...')
    )
