### PR TITLE
Move 'nose' dependency to 'tests_require'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=['pkgconfig'],
     description="Interface Python with pkg-config",
     long_description=open('README.rst').read(),
-    setup_requires=['nose>=1.0'],
+    tests_require=['nose>=1.0'],
     python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
     test_suite='test',
 )


### PR DESCRIPTION
`nose` is only required for invoking `setup.py test`, not for any other
`setup.py` command.  This avoids the auto-download behavior when just
building and installing the module (e.g., installing via `pip`).

Signed-off-by: Eric N. Vander Weele <ericvw@gmail.com>