### PR TITLE
Include original OSError in convert_error

### DIFF
--- a/pkgconfig/pkgconfig.py
+++ b/pkgconfig/pkgconfig.py
@@ -58,8 +58,8 @@ def _convert_error(func):
     def _wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except OSError:
-            raise EnvironmentError("pkg-config is not installed")
+        except OSError as e:
+            raise EnvironmentError("pkg-config is probably not installed") from e
 
     return _wrapper
 

--- a/pkgconfig/pkgconfig.py
+++ b/pkgconfig/pkgconfig.py
@@ -59,8 +59,7 @@ def _convert_error(func):
         try:
             return func(*args, **kwargs)
         except OSError as e:
-            raise EnvironmentError("pkg-config is probably not installed") from e
-
+            raise EnvironmentError("pkg-config is probably not installed. Could not run pkg-config: %r"%e)
     return _wrapper
 
 


### PR DESCRIPTION
An OSError could be there for other reasons. It's nice to report back what the actual cause was.