### PR TITLE
ci: Enable Python 3.7 to be tested against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ python:
     - "3.5"
     - "3.6"
 
+# Enable 3.7 without globally enabling `dist: xenial` for other build jobs.
+matrix:
+    include:
+        - python: "3.7"
+          dist: xenial
+
 install:
     - pip install nose
 


### PR DESCRIPTION
Now that Python 3.7 is available, enable CI to run tests against it.