### PR TITLE
fix version parsing for openssl-like version numbers, fixes #32

### DIFF
--- a/data/fake-dld-pkg.pc
+++ b/data/fake-dld-pkg.pc
@@ -1,0 +1,9 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: BetaPkg
+Description: fake package with a digit-letter-digit version number for testing
+Requires:
+Version: 1.2.3b4

--- a/data/fake-openssl.pc
+++ b/data/fake-openssl.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib/x86_64-linux-gnu
+includedir=${prefix}/include
+
+Name: OpenSSL
+Description: Secure Sockets Layer and cryptography libraries and tools
+Requires: libssl libcrypto
+Version: 1.1.0j
+

--- a/pkgconfig/pkgconfig.py
+++ b/pkgconfig/pkgconfig.py
@@ -35,11 +35,33 @@ def _compare_versions(v1, v2):
     Compare two version strings and return -1, 0 or 1 depending on the equality
     of the subset of matching version numbers.
 
-    The implementation is taken from the top answer at
+    The implementation is inspired by the top answer at
     http://stackoverflow.com/a/1714190/997768.
     """
     def normalize(v):
-        return [int(x) for x in re.sub(r'(\.0+)*$', '', v).split(".")]
+        # strip trailing .0 or .00 or .0.0 or ...
+        v = re.sub(r'(\.0+)*$', '', v)
+        result = []
+        for part in v.split('.'):
+            # just digits
+            m = re.match(r'^(\d+)$', part)
+            if m:
+                result.append(int(m.group(1)))
+                continue
+            # digits letters
+            m = re.match(r'^(\d+)([a-zA-Z]+)$', part)
+            if m:
+                result.append(int(m.group(1)))
+                result.append(m.group(2))
+                continue
+            # digits letters digits
+            m = re.match(r'^(\d+)([a-zA-Z]+)(\d+)$', part)
+            if m:
+                result.append(int(m.group(1)))
+                result.append(m.group(2))
+                result.append(int(m.group(3)))
+                continue
+        return tuple(result)
 
     n1 = normalize(v1)
     n2 = normalize(v2)
@@ -49,7 +71,7 @@ def _compare_versions(v1, v2):
 
 def _split_version_specifier(spec):
     """Splits version specifiers in the form ">= 0.1.2" into ('0.1.2', '>=')"""
-    m = re.search(r'([<>=]?=?)?\s*((\d*\.)*\d*)', spec)
+    m = re.search(r'([<>=]?=?)?\s*([0-9.a-zA-Z]+)', spec)
     return m.group(2), m.group(1)
 
 

--- a/test_pkgconfig.py
+++ b/test_pkgconfig.py
@@ -8,7 +8,7 @@ PACKAGE_NAME = 'fake-gtk+-3.0'
 
 def test_exists():
     assert pkgconfig.exists(PACKAGE_NAME)
-
+    assert pkgconfig.exists('fake-openssl')
 
 @pytest.mark.parametrize("version,expected",[
     ('3.2.1', True),
@@ -23,8 +23,58 @@ def test_version(version, expected):
     assert pkgconfig.installed(PACKAGE_NAME, version) == expected
 
 
+@pytest.mark.parametrize("version,expected",[
+    ('1.1.0j', True),
+    ('==1.1.0j', True),
+    ('==1.1.0k', False),
+    ('>= 1.1.0', True),
+    ('> 1.2.0', False),
+    ('< 1.2.0', True),
+    ('< 1.1.0', False),
+    ('>= 1.1', True),
+    ('> 1.2', False),
+    ('< 1.2', True),
+    ('< 1.1', False),
+    ('>= 1.1.0c', True),
+    ('>= 1.1.0k', False),
+    # PLEASE NOTE:
+    # the letters have no semantics, except string ordering, see also the
+    # comment in the test below.
+    # comparing release with beta, like "1.2.3" > "1.2.3b" does not work.
+])
+def test_openssl(version, expected):
+    assert pkgconfig.installed('fake-openssl', version) == expected
+
+
+@pytest.mark.parametrize("version,expected",[
+    ('1.2.3b4', True),
+    ('==1.2.3b4', True),
+    ('==1.2.3', False),
+    ('>= 1.2.3b3', True),
+    ('< 1.2.3b5', True),
+    # PLEASE NOTE:
+    # sadly, when looking at all (esp. non-python) libraries out there, there
+    # is no agreement on the semantics of letters appended to version numbers.
+    # e.g. for a release candidate, some might use "c", but other also might
+    # use "rc" or whatever. stuff like openssl does not use the letters to
+    # represent release status, but rather minor updates using a-z.
+    # so, as there is no real standard / agreement, we can NOT assume any
+    # advanced semantics here (like we could for python packages).
+    # thus we do NOT implement any special semantics for the letters,
+    # except string ordering
+    # thus, comparing a version with a letter-digits appendix to one without
+    # may or may not give the desired result.
+    # e.g. python packages use a1 for alpha 1, b2 for beta 2, c3 for release
+    # candidate 3 and <nothing> for release.
+    # we do not implement this semantics, "1.2.3" > "1.2.3b1" does not work.
+])
+def test_dld_pkg(version, expected):
+    assert pkgconfig.installed('fake-dld-pkg', version) == expected
+
+
 def test_modversion():
     assert pkgconfig.modversion(PACKAGE_NAME) == '3.2.1'
+    assert pkgconfig.modversion('fake-openssl') == '1.1.0j'
 
 
 def test_cflags():


### PR DESCRIPTION
also:
- added openssl test data, version 1.1.0j
- added tests

I had to make _split_version_specifier a bit more sloppy, so it matches version numbers like 1.1.0j or 1.2.3b2.