### PR TITLE
parse: do not have empty-list members in defaultdict with empty-list default

### DIFF
--- a/pkgconfig/pkgconfig.py
+++ b/pkgconfig/pkgconfig.py
@@ -224,7 +224,8 @@ def parse(packages, static=False):
 
     result['define_macros'] = [split(m) for m in result['define_macros']]
 
-    return result
+    # only have members with values not being the empty list (which is default anyway):
+    return collections.defaultdict(list, ((k, v) for k, v in result.items() if v != []))
 
 
 def list_all():


### PR DESCRIPTION
see #40.