### PR TITLE
ARM64: Add ARM64 jobs in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,22 @@
 language: python
 
 python:
-    - "2.6"
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
     - "3.6"
-
+os: linux
+arch: 
+    - amd64
+    - arm64
 # Enable 3.7 without globally enabling `dist: xenial` for other build jobs.
 matrix:
     include:
         - python: "3.7"
           dist: xenial
-
+        - python: "3.7"
+          arch: arm64
+          dist: xenial
 install:
     - pip install pytest
 


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 jobs in Travis-CI.