### PR TITLE
Make it easier to add --cflags/--libs to a setuptools Extension.

### DIFF
--- a/pkgconfig/pkgconfig.py
+++ b/pkgconfig/pkgconfig.py
@@ -267,6 +267,24 @@ def parse(packages, static=False):
     return collections.defaultdict(list, ((k, v) for k, v in result.items() if v))
 
 
+def configure_extension(ext, packages, static=False):
+    """
+    Append the ``--cflags`` and ``--libs`` of a space-separated list of
+    *packages* to the ``extra_compile_args`` and ``extra_link_args`` of a
+    distutils/setuptools ``Extension``.
+    """
+    for package in packages.split():
+        _raise_if_not_exists(package)
+
+    def query_and_extend(option, target):
+        os_opts = ['--msvc-syntax'] if os.name == 'nt' else []
+        flags = _query(packages, *os_opts, *_build_options(option, static=static))
+        target.extend(re.split(r'(?<!\\) ', flags.replace('\\"', '')))
+
+    query_and_extend('--cflags', ext.extra_compile_args)
+    query_and_extend('--libs', ext.extra_link_args)
+
+
 def list_all():
     """Return a list of all packages found by pkg-config."""
     packages = [line.split()[0] for line in _query('', '--list-all').split('\n')]

--- a/test_pkgconfig.py
+++ b/test_pkgconfig.py
@@ -1,3 +1,4 @@
+from distutils.core import Extension
 import os
 import pytest
 import pkgconfig
@@ -132,6 +133,15 @@ def test_parse_static():
     assert 'pthread' in config['libraries']
     assert 'dl' in config['libraries']
     assert 'util' in config['libraries']
+
+
+def test_configure_extension():
+    ext = Extension('foo', ['foo.c'])
+    pkgconfig.configure_extension(ext, 'fake-gtk+-3.0 fake-python')
+    assert ext.extra_compile_args == [
+        '-I/usr/include/gtk-3.0', '-DGSEAL_ENABLE', '-I/usr/include/python2.7']
+    assert ext.extra_link_args == [
+        '-L/usr/lib_gtk_foo', '-lgtk-3', '-L/usr/lib_python_foo', '-lpython2.7']
 
 
 def test_listall():


### PR DESCRIPTION
The previous solution was to use `parse()` with something like
`Extension("foo", ["foo.c"], **parse(...))`, but

1) that would not work if there are other include dirs (etc.) that
   needed to be passed manually, in which case one had to look oneself
   over the dict entries
   (`ext = Extension(..., libraries=["manualentry"])`
   `for k, v in parse(...).items(): getattr(ext, k).extend(v)`)

2) some flags are not parsed correctly (e.g. `--fopenmp`, #38), but for the
   specific use-case of setuptools Extensions, we don't care about flag
   semantics, we can just mindlessly dump everything into
   `extra_{compile,link}_args`.