### PR TITLE
Drop 2.7 support from metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "~2.7 || ^3.3"
+python = "^3.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.8.2"


### PR DESCRIPTION
The package already has Python 3 only syntax, this will allow pip to
know that it should not install it for a Python 2 environment.

Closes #56 