### PR TITLE
Fix configure_extension for empty cflags or libs.

### DIFF
--- a/data/fake-ldonly-pkg.pc
+++ b/data/fake-ldonly-pkg.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: FakeLdOnly
+Description: fake package with only libs, not cflags
+Requires:
+Version: 1.2.3
+Libs: -L${libdir} -lfakeldonly

--- a/pkgconfig/pkgconfig.py
+++ b/pkgconfig/pkgconfig.py
@@ -279,7 +279,9 @@ def configure_extension(ext, packages, static=False):
     def query_and_extend(option, target):
         os_opts = ['--msvc-syntax'] if os.name == 'nt' else []
         flags = _query(packages, *os_opts, *_build_options(option, static=static))
-        target.extend(re.split(r'(?<!\\) ', flags.replace('\\"', '')))
+        flags = flags.replace('\\"', '')
+        if flags:
+            target.extend(re.split(r'(?<!\\) ', flags))
 
     query_and_extend('--cflags', ext.extra_compile_args)
     query_and_extend('--libs', ext.extra_link_args)

--- a/test_pkgconfig.py
+++ b/test_pkgconfig.py
@@ -143,6 +143,11 @@ def test_configure_extension():
     assert ext.extra_link_args == [
         '-L/usr/lib_gtk_foo', '-lgtk-3', '-L/usr/lib_python_foo', '-lpython2.7']
 
+    ext = Extension('foo', ['foo.c'])
+    pkgconfig.configure_extension(ext, 'fake-ldonly-pkg')
+    assert ext.extra_compile_args == []
+    assert ext.extra_link_args == ['-lfakeldonly']
+
 
 def test_listall():
     packages = pkgconfig.list_all()


### PR DESCRIPTION
The previous implementation would incorrectly insert an empty string in
the args list if --cflags or --libs returned nothing (because
`re.split(pat, "")` returns `[""]`, not `[]`), which would cause errors
in a subsequent gcc invocation.  Fortunately, this is straightforward to
fix.

Apologies for only catching that after the release.