### PR TITLE
test_configure_extension: sorted expected

### DIFF
--- a/test_pkgconfig.py
+++ b/test_pkgconfig.py
@@ -138,9 +138,9 @@ def test_parse_static():
 def test_configure_extension():
     ext = Extension('foo', ['foo.c'])
     pkgconfig.configure_extension(ext, 'fake-gtk+-3.0 fake-python')
-    assert ext.extra_compile_args == [
+    assert sorted(ext.extra_compile_args) == [
          '-DGSEAL_ENABLE', '-I/usr/include/gtk-3.0','-I/usr/include/python2.7']
-    assert ext.extra_link_args == [
+    assert sorted(ext.extra_link_args) == [
         '-L/usr/lib_gtk_foo', '-L/usr/lib_python_foo', '-lgtk-3', '-lpython2.7']
 
 


### PR DESCRIPTION
* `pkg-config` output order isn't specified, so
  check against the sorted output.

Bug: https://bugs.gentoo.org/799290